### PR TITLE
Use API instead of context for fetching labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,12 @@ async function run() {
 
     const failMessages = []
 
-    const prLabels = context.payload.pull_request.labels.map(item => item.name)
+    const { data: labelsOnIssue } = await octokit.issues.listLabelsOnIssue({
+      ...context.repo,
+      issue_number: context.payload.pull_request.number
+    })
+
+    const prLabels = labelsOnIssue.map(item => item.name)
 
     const hasSomeResult = !hasSomeInput || hasSomeLabels.some((label) =>
       prLabels.includes(label)

--- a/index.js
+++ b/index.js
@@ -2,106 +2,110 @@ const core = require('@actions/core')
 const github = require('@actions/github')
 
 async function run() {
-  // check if this is running on a pull request
-  if (!github.context.payload.pull_request) {
-    return core.setOutput('passed', true)
-  }
+  try {
+    // check if this is running on a pull request
+    if (!github.context.payload.pull_request) {
+      return core.setOutput('passed', true)
+    }
 
-  const token = core.getInput('githubToken');
-  const context = github.context
-  const octokit = github.getOctokit(token)
+    const token = core.getInput('githubToken');
+    const context = github.context
+    const octokit = github.getOctokit(token)
 
-  const hasSomeInput = core.getInput('hasSome')
-  const hasAllInput = core.getInput('hasAll')
-  const hasNoneInput = core.getInput('hasNone')
-  const hasNotAllInput = core.getInput('hasNotAll')
+    const hasSomeInput = core.getInput('hasSome')
+    const hasAllInput = core.getInput('hasAll')
+    const hasNoneInput = core.getInput('hasNone')
+    const hasNotAllInput = core.getInput('hasNotAll')
 
-  const hasSomeLabels = hasSomeInput.split(',')
-  const hasAllLabels = hasAllInput.split(',')
-  const hasNoneLabels = hasNoneInput.split(',')
-  const hasNotAllLabels = hasNotAllInput.split(',')
+    const hasSomeLabels = hasSomeInput.split(',')
+    const hasAllLabels = hasAllInput.split(',')
+    const hasNoneLabels = hasNoneInput.split(',')
+    const hasNotAllLabels = hasNotAllInput.split(',')
 
-  const failMessages = []
+    const failMessages = []
 
-  const prLabels = context.payload.pull_request.labels.map(item => item.name)
+    const prLabels = context.payload.pull_request.labels.map(item => item.name)
 
-  const hasSomeResult = !hasSomeInput || hasSomeLabels.some((label) =>
-    prLabels.includes(label)
-  )
+    const hasSomeResult = !hasSomeInput || hasSomeLabels.some((label) =>
+      prLabels.includes(label)
+    )
 
-  const hasAllResult = !hasAllInput || hasAllLabels.every((label) =>
-    prLabels.includes(label)
-  )
+    const hasAllResult = !hasAllInput || hasAllLabels.every((label) =>
+      prLabels.includes(label)
+    )
 
-  const hasNoneResult = !hasNoneInput || hasNoneLabels.every((label) =>
-    !prLabels.includes(label)
-  )
+    const hasNoneResult = !hasNoneInput || hasNoneLabels.every((label) =>
+      !prLabels.includes(label)
+    )
 
-  const hasNotAllResult = !hasNotAllInput || hasNotAllLabels.some((label) =>
-    !prLabels.includes(label)
-  )
+    const hasNotAllResult = !hasNotAllInput || hasNotAllLabels.some((label) =>
+      !prLabels.includes(label)
+    )
 
-  if (!hasSomeResult) {
-    failMessages.push(`The PR needs to have at least one of the following labels to pass this check: ${hasSomeLabels.join(
-      ', '
-    )}`)
-  }
+    if (!hasSomeResult) {
+      failMessages.push(`The PR needs to have at least one of the following labels to pass this check: ${hasSomeLabels.join(
+        ', '
+      )}`)
+    }
 
-  if (!hasAllResult) {
-    failMessages.push(`The PR needs to have all of the following labels to pass this check: ${hasAllLabels.join(
-      ', '
-    )}`)
-  }
+    if (!hasAllResult) {
+      failMessages.push(`The PR needs to have all of the following labels to pass this check: ${hasAllLabels.join(
+        ', '
+      )}`)
+    }
 
-  if (!hasNoneResult) {
-    failMessages.push(`The PR needs to have none of the following labels to pass this check: ${hasNoneLabels.join(
-      ', '
-    )}`)
-  }
+    if (!hasNoneResult) {
+      failMessages.push(`The PR needs to have none of the following labels to pass this check: ${hasNoneLabels.join(
+        ', '
+      )}`)
+    }
 
-  if (!hasNotAllResult) {
-    failMessages.push(`The PR needs to not have at least one of the following labels to pass this check: ${hasNotAllLabels.join(
-      ', '
-    )}`)
-  }
+    if (!hasNotAllResult) {
+      failMessages.push(`The PR needs to not have at least one of the following labels to pass this check: ${hasNotAllLabels.join(
+        ', '
+      )}`)
+    }
   
-  const checks = await octokit.checks.listForRef({
-    ...context.repo,
-    ref: context.payload.pull_request.head.ref,
-  });
+    const checks = await octokit.checks.listForRef({
+      ...context.repo,
+      ref: context.payload.pull_request.head.ref,
+    });
 
-  const checkRunIds = checks.data.check_runs.filter(check => check.name === context.job).map(check => check.id)
+    const checkRunIds = checks.data.check_runs.filter(check => check.name === context.job).map(check => check.id)
 
-  if (failMessages.length) {
-    // update old checks
-    for (const id of checkRunIds) {
-      await octokit.checks.update({
-        ...context.repo,
-        check_run_id: id,
-        conclusion: 'failure',
-        output: {
-          title: 'Labels did not pass provided rules',
-          summary: failMessages.join('. ')
-        }
-      })
+    if (failMessages.length) {
+      // update old checks
+      for (const id of checkRunIds) {
+        await octokit.checks.update({
+          ...context.repo,
+          check_run_id: id,
+          conclusion: 'failure',
+          output: {
+            title: 'Labels did not pass provided rules',
+            summary: failMessages.join('. ')
+          }
+        })
+      }
+
+      core.setFailed(failMessages.join('. '))
+    } else {
+      // update old checks
+      for (const id of checkRunIds) {
+        await octokit.checks.update({
+          ...context.repo,
+          check_run_id: id,
+          conclusion: 'success',
+          output: {
+            title: 'Labels follow all the provided rules',
+            summary: ''
+          }
+        })
+      }
+
+      core.setOutput('passed', true)
     }
-
-    core.setFailed(failMessages.join('. '))
-  } else {
-    // update old checks
-    for (const id of checkRunIds) {
-      await octokit.checks.update({
-        ...context.repo,
-        check_run_id: id,
-        conclusion: 'success',
-        output: {
-          title: 'Labels follow all the provided rules',
-          summary: ''
-        }
-      })
-    }
-
-    core.setOutput('passed', true)
+  } catch (error) {
+    core.setFailed(error.message)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,71 +1,70 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
 
-// check if this is running on a pull request
-if (!github.context.payload.pull_request) {
-  return core.setOutput('passed', true)
-}
+async function run() {
+  // check if this is running on a pull request
+  if (!github.context.payload.pull_request) {
+    return core.setOutput('passed', true)
+  }
 
-const token = core.getInput('githubToken');
-const context = github.context
-const octokit = github.getOctokit(token)
+  const token = core.getInput('githubToken');
+  const context = github.context
+  const octokit = github.getOctokit(token)
 
-const hasSomeInput = core.getInput('hasSome')
-const hasAllInput = core.getInput('hasAll')
-const hasNoneInput = core.getInput('hasNone')
-const hasNotAllInput = core.getInput('hasNotAll')
+  const hasSomeInput = core.getInput('hasSome')
+  const hasAllInput = core.getInput('hasAll')
+  const hasNoneInput = core.getInput('hasNone')
+  const hasNotAllInput = core.getInput('hasNotAll')
 
-const hasSomeLabels = hasSomeInput.split(',')
-const hasAllLabels = hasAllInput.split(',')
-const hasNoneLabels = hasNoneInput.split(',')
-const hasNotAllLabels = hasNotAllInput.split(',')
+  const hasSomeLabels = hasSomeInput.split(',')
+  const hasAllLabels = hasAllInput.split(',')
+  const hasNoneLabels = hasNoneInput.split(',')
+  const hasNotAllLabels = hasNotAllInput.split(',')
 
-const failMessages = []
+  const failMessages = []
 
+  const prLabels = context.payload.pull_request.labels.map(item => item.name)
 
-const prLabels = context.payload.pull_request.labels.map(item => item.name)
+  const hasSomeResult = !hasSomeInput || hasSomeLabels.some((label) =>
+    prLabels.includes(label)
+  )
 
-const hasSomeResult = !hasSomeInput || hasSomeLabels.some((label) =>
-  prLabels.includes(label)
-)
+  const hasAllResult = !hasAllInput || hasAllLabels.every((label) =>
+    prLabels.includes(label)
+  )
 
-const hasAllResult = !hasAllInput || hasAllLabels.every((label) =>
-  prLabels.includes(label)
-)
+  const hasNoneResult = !hasNoneInput || hasNoneLabels.every((label) =>
+    !prLabels.includes(label)
+  )
 
-const hasNoneResult = !hasNoneInput || hasNoneLabels.every((label) =>
-  !prLabels.includes(label)
-)
+  const hasNotAllResult = !hasNotAllInput || hasNotAllLabels.some((label) =>
+    !prLabels.includes(label)
+  )
 
-const hasNotAllResult = !hasNotAllInput || hasNotAllLabels.some((label) =>
-  !prLabels.includes(label)
-)
+  if (!hasSomeResult) {
+    failMessages.push(`The PR needs to have at least one of the following labels to pass this check: ${hasSomeLabels.join(
+      ', '
+    )}`)
+  }
 
-if (!hasSomeResult) {
-  failMessages.push(`The PR needs to have at least one of the following labels to pass this check: ${hasSomeLabels.join(
-    ', '
-  )}`)
-}
+  if (!hasAllResult) {
+    failMessages.push(`The PR needs to have all of the following labels to pass this check: ${hasAllLabels.join(
+      ', '
+    )}`)
+  }
 
-if (!hasAllResult) {
-  failMessages.push(`The PR needs to have all of the following labels to pass this check: ${hasAllLabels.join(
-    ', '
-  )}`)
-}
+  if (!hasNoneResult) {
+    failMessages.push(`The PR needs to have none of the following labels to pass this check: ${hasNoneLabels.join(
+      ', '
+    )}`)
+  }
 
-if (!hasNoneResult) {
-  failMessages.push(`The PR needs to have none of the following labels to pass this check: ${hasNoneLabels.join(
-    ', '
-  )}`)
-}
-
-if (!hasNotAllResult) {
-  failMessages.push(`The PR needs to not have at least one of the following labels to pass this check: ${hasNotAllLabels.join(
-    ', '
-  )}`)
-}
-
-async function run () {
+  if (!hasNotAllResult) {
+    failMessages.push(`The PR needs to not have at least one of the following labels to pass this check: ${hasNotAllLabels.join(
+      ', '
+    )}`)
+  }
+  
   const checks = await octokit.checks.listForRef({
     ...context.repo,
     ref: context.payload.pull_request.head.ref,


### PR DESCRIPTION
# What has been done in this PR?

Change the data origin for the labels to the HTTP API by using Octokit. This allows using the action in the same job that updates the labels (using something like [TimonVS/pr-labeler-action](https://github.com/TimonVS/pr-labeler-action)).

## Other changes

- Move the whole code of the action inside the `run` function, as [GitHub suggests](https://github.com/actions/javascript-action/blob/main/index.js).
- Wrap the action's code in a `try`/`catch` to correctly fail on errors. 