### PR TITLE
fix: bump to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ outputs:
   passed:
     description: "Have the provided labels passed all tests?"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.cjs"
 branding:
   icon: "tag"


### PR DESCRIPTION
We've been getting some errors from github telling us that this action will be forced to use node16 soon: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default 

Realistically we can just bump this to node20 if that seems alright, I don't see any complications. Thoughts? 