### PR TITLE
fix: Remove unsupported GitHub API

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -10542,25 +10542,25 @@ async function run() {
   try {
     // check if this is running on a pull request
     if (!github.context.payload.pull_request) {
-      return core.setOutput("passed", true);
+      return core.setOutput('passed', true);
     }
 
-    const token = core.getInput("githubToken");
+    const token = core.getInput('githubToken');
     const context = github.context;
     const octokit = github.getOctokit(token);
 
-    const hasSomeInput = core.getInput("hasSome");
-    const hasAllInput = core.getInput("hasAll");
-    const hasNoneInput = core.getInput("hasNone");
-    const hasNotAllInput = core.getInput("hasNotAll");
+    const hasSomeInput = core.getInput('hasSome');
+    const hasAllInput = core.getInput('hasAll');
+    const hasNoneInput = core.getInput('hasNone');
+    const hasNotAllInput = core.getInput('hasNotAll');
 
     const hasSomeLabels = parseInputTags(hasSomeInput);
     const hasAllLabels = parseInputTags(hasAllInput);
     const hasNoneLabels = parseInputTags(hasNoneInput);
     const hasNotAllLabels = parseInputTags(hasNotAllInput);
 
-    const allowFailureInput = core.getInput("allowFailure");
-    const allowFailure = allowFailureInput === "true";
+    const allowFailureInput = core.getInput('allowFailure');
+    const allowFailure = allowFailureInput === 'true';
 
     const failMessages = [];
 
@@ -10588,7 +10588,7 @@ async function run() {
     if (!hasSomeResult) {
       failMessages.push(
         `The PR needs to have at least one of the following labels to pass this check: ${hasSomeLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
@@ -10596,7 +10596,7 @@ async function run() {
     if (!hasAllResult) {
       failMessages.push(
         `The PR needs to have all of the following labels to pass this check: ${hasAllLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
@@ -10604,7 +10604,7 @@ async function run() {
     if (!hasNoneResult) {
       failMessages.push(
         `The PR needs to have none of the following labels to pass this check: ${hasNoneLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
@@ -10612,52 +10612,19 @@ async function run() {
     if (!hasNotAllResult) {
       failMessages.push(
         `The PR needs to not have at least one of the following labels to pass this check: ${hasNotAllLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
 
-    const checks = await octokit.checks.listForRef({
-      ...context.repo,
-      ref: context.payload.pull_request.head.ref,
-    });
-
-    const checkRunIds = checks.data.check_runs
-      .filter((check) => check.name === context.job)
-      .map((check) => check.id);
-
     if (failMessages.length) {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: allowFailure ? "success" : "failure",
-          output: {
-            title: "Labels did not pass provided rules",
-            summary: failMessages.join(". "),
-          },
-        });
-      }
-
       if (!allowFailure) {
-        core.setFailed(failMessages.join(". "));
+        core.setFailed(failMessages.join('. '));
+      } else {
+        core.setOutput(failMessages.join('. '), true);
       }
     } else {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: "success",
-          output: {
-            title: "Labels follow all the provided rules",
-            summary: "",
-          },
-        });
-      }
-
-      core.setOutput("passed", true);
+      core.setOutput('passed', true);
     }
   } catch (error) {
     core.setFailed(error.message);

--- a/index.cjs
+++ b/index.cjs
@@ -1,30 +1,30 @@
-const core = require("@actions/core");
-const github = require("@actions/github");
-const { parseInputTags } = require("./utils.cjs");
+const core = require('@actions/core');
+const github = require('@actions/github');
+const { parseInputTags } = require('./utils.cjs');
 
 async function run() {
   try {
     // check if this is running on a pull request
     if (!github.context.payload.pull_request) {
-      return core.setOutput("passed", true);
+      return core.setOutput('passed', true);
     }
 
-    const token = core.getInput("githubToken");
+    const token = core.getInput('githubToken');
     const context = github.context;
     const octokit = github.getOctokit(token);
 
-    const hasSomeInput = core.getInput("hasSome");
-    const hasAllInput = core.getInput("hasAll");
-    const hasNoneInput = core.getInput("hasNone");
-    const hasNotAllInput = core.getInput("hasNotAll");
+    const hasSomeInput = core.getInput('hasSome');
+    const hasAllInput = core.getInput('hasAll');
+    const hasNoneInput = core.getInput('hasNone');
+    const hasNotAllInput = core.getInput('hasNotAll');
 
     const hasSomeLabels = parseInputTags(hasSomeInput);
     const hasAllLabels = parseInputTags(hasAllInput);
     const hasNoneLabels = parseInputTags(hasNoneInput);
     const hasNotAllLabels = parseInputTags(hasNotAllInput);
 
-    const allowFailureInput = core.getInput("allowFailure");
-    const allowFailure = allowFailureInput === "true";
+    const allowFailureInput = core.getInput('allowFailure');
+    const allowFailure = allowFailureInput === 'true';
 
     const failMessages = [];
 
@@ -52,7 +52,7 @@ async function run() {
     if (!hasSomeResult) {
       failMessages.push(
         `The PR needs to have at least one of the following labels to pass this check: ${hasSomeLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
@@ -60,7 +60,7 @@ async function run() {
     if (!hasAllResult) {
       failMessages.push(
         `The PR needs to have all of the following labels to pass this check: ${hasAllLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
@@ -68,7 +68,7 @@ async function run() {
     if (!hasNoneResult) {
       failMessages.push(
         `The PR needs to have none of the following labels to pass this check: ${hasNoneLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
@@ -76,52 +76,19 @@ async function run() {
     if (!hasNotAllResult) {
       failMessages.push(
         `The PR needs to not have at least one of the following labels to pass this check: ${hasNotAllLabels.join(
-          ", "
+          ', '
         )}`
       );
     }
 
-    const checks = await octokit.checks.listForRef({
-      ...context.repo,
-      ref: context.payload.pull_request.head.ref,
-    });
-
-    const checkRunIds = checks.data.check_runs
-      .filter((check) => check.name === context.job)
-      .map((check) => check.id);
-
     if (failMessages.length) {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: allowFailure ? "success" : "failure",
-          output: {
-            title: "Labels did not pass provided rules",
-            summary: failMessages.join(". "),
-          },
-        });
-      }
-
       if (!allowFailure) {
-        core.setFailed(failMessages.join(". "));
+        core.setFailed(failMessages.join('. '));
+      } else {
+        core.setOutput(failMessages.join('. '), true);
       }
     } else {
-      // update old checks
-      for (const id of checkRunIds) {
-        await octokit.checks.update({
-          ...context.repo,
-          check_run_id: id,
-          conclusion: "success",
-          output: {
-            title: "Labels follow all the provided rules",
-            summary: "",
-          },
-        });
-      }
-
-      core.setOutput("passed", true);
+      core.setOutput('passed', true);
     }
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Today, I got the following error in GitHub Actions.

> Run danielchabr/pr-labels-checker@v3.3
Error: Check run status and conclusions can only be updated internally by GitHub Actions. Please see https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/#changes-to-check-run-status-modification

We can't use `octokit.checks.update` in GitHub Actions, so I remove them.

Before merging this PR, we can use the following code to resolve the error.

```diff
- uses: danielchabr/pr-labels-checker@v3.3
+ uses: danielchabr/pr-labels-checker@0e33fbeaa8f1327a212d8aa5ade2700776ba61d7
```
